### PR TITLE
Adds Direct Insertion Support for Offers.

### DIFF
--- a/src/Updatedge.Common/Models/Offer/CreateOffer.cs
+++ b/src/Updatedge.Common/Models/Offer/CreateOffer.cs
@@ -47,5 +47,10 @@ namespace Updatedge.Common.Models.Offer
         /// The dates and times of the events to offer
         /// </summary>
         public IEnumerable<BaseInterval> Events { get; set; }
+        
+        /// <summary>
+        /// Whether this offer should be directly inserted into the worker's timeline
+        /// </summary>
+        public bool DirectInsertion { get; set; }
     }
 }

--- a/src/Updatedge.net/Updatedge.net.csproj
+++ b/src/Updatedge.net/Updatedge.net.csproj
@@ -8,7 +8,7 @@
     <Description>C# wrapper for the updatedge API</Description>
     <Copyright>updatedge Ltd 2020</Copyright>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
-    <Version>1.0.10</Version>
+    <Version>1.0.11</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Setting directInsertion to true when creating an offer now adds the offer to the worker's timeline automatically if there are no conflicts.