### PR TITLE
Fixed internal interface to public

### DIFF
--- a/src/Updatedge.net/Services/V1/IScheduleService.cs
+++ b/src/Updatedge.net/Services/V1/IScheduleService.cs
@@ -6,7 +6,7 @@ using Updatedge.Common.Models.Availability;
 
 namespace Updatedge.net.Services.V1
 {
-    internal interface IScheduleService
+    public interface IScheduleService
     {
         Task<string> GetTeachersAvailabilityPublicUrl(HirerScheduleUrlRequest request);
     }


### PR DESCRIPTION
Re-declares the schedule service interface as public correctly