### PR TITLE
Replace consolidated events functionality

### DIFF
--- a/src/Updatedge.Common/Models/Offer/CreateOfferEvent.cs
+++ b/src/Updatedge.Common/Models/Offer/CreateOfferEvent.cs
@@ -4,17 +4,11 @@ using System.Text;
 
 namespace Updatedge.Common.Models.Offer
 {
-    public class EventDelete
+    public class CreateOfferEvent
     {
         public string OfferId { get; set; }
-        public string UserId { get; set; }
-        public string Reason { get; set; }
         public DateTimeOffset Start { get; set; }
         public DateTimeOffset End { get; set; }
-    }
-
-    public class EventDeleteOnDay
-    {
-        public DateTimeOffset Date { get; set; }
+        public int AdjustedLengthMins { get; set; }
     }
 }

--- a/src/Updatedge.net/Services/V1/IOfferService.cs
+++ b/src/Updatedge.net/Services/V1/IOfferService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Updatedge.Common.Models.Offer;
 
@@ -55,5 +56,7 @@ namespace Updatedge.net.Services.V1
         Task<bool> DeleteEventFromOfferAsync(EventDelete request);
         Task<bool> DeleteEventsFromOfferAsync(List<EventDelete> request);
         Task<string> AlterConfirmedOfferAsync(string id, AlterOffer alterations);
+        Task<string> CreateOfferEventAsync(CreateOfferEvent offerEvent);
+        Task<bool> DeleteEventsOnDayFromOfferAsync(string offerId, DateTimeOffset date);
     }
 }

--- a/src/Updatedge.net/Services/V1/OfferService.cs
+++ b/src/Updatedge.net/Services/V1/OfferService.cs
@@ -1,5 +1,6 @@
 ﻿using Flurl;
 using Flurl.Http;
+using Microsoft.AspNetCore.Http;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -48,6 +49,18 @@ namespace Updatedge.net.Services.V1
             {
                 throw await flEx.Handle();
             }
+        }
+
+        public async virtual Task<string> CreateOfferEventAsync(CreateOfferEvent offerEvent)
+        {
+            var response = await BaseUrl
+                     .AppendPathSegment($"offer/{offerEvent.OfferId}/offerevent")
+                     .SetQueryParam("api-version", ApiVersion)
+                     .WithHeader(ApiKeyName, ApiKey)
+                     .PostJsonAsync(offerEvent)
+                     .ReceiveString();
+
+            return response;
         }
 
         public async virtual Task<Offer> GetOfferAsync(string id)
@@ -169,6 +182,24 @@ namespace Updatedge.net.Services.V1
                     .SetQueryParam("api-version", ApiVersion)
                     .WithHeader(ApiKeyName, ApiKey)
                     .SendJsonAsync(HttpMethod.Delete, request);
+
+                return response.IsSuccessStatusCode;
+            }
+            catch (FlurlHttpException flEx)
+            {
+                throw await flEx.Handle();
+            }
+        }
+
+        public virtual async Task<bool> DeleteEventsOnDayFromOfferAsync(string offerId, DateTimeOffset date)
+        {
+            try
+            {
+                var response = await BaseUrl
+                    .AppendPathSegment($"offer/{offerId}/eventsOnDay")
+                    .SetQueryParam("api-version", ApiVersion)
+                    .WithHeader(ApiKeyName, ApiKey)
+                    .SendJsonAsync(HttpMethod.Delete, new EventDeleteOnDay() { Date = date });
 
                 return response.IsSuccessStatusCode;
             }


### PR DESCRIPTION
Adds end points to delete and add events to an offer.  This supports replacement of consolidated events when a part of the day is removed.